### PR TITLE
Fix Sql Table Update

### DIFF
--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -204,7 +204,6 @@ class PACKED ProjectedColumns {
                                                          common::RawBitmap::SizeInBytes(max_tuples_));
   }
 
-
  private:
   friend class ProjectedColumnsInitializer;
   uint32_t size_;

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -313,6 +313,6 @@ class SqlTable {
    */
   template <class RowType>
   void ModifyProjectionHeaderForVersion(RowType *out_buffer, const DataTableVersion &curr_dt_version,
-                                        const DataTableVersion &old_dt_version, col_id_t * original_col_id_store) const;
+                                        const DataTableVersion &old_dt_version, col_id_t *original_col_id_store) const;
 };
 }  // namespace terrier::storage

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -247,6 +247,7 @@ std::pair<bool, storage::TupleSlot> SqlTable::Update(transaction::TransactionCon
       new_slot = tables_.at(version_num).data_table->Insert(txn, *new_pr);
     } else {
       // someone else deleted the old row, write-write conflict
+      delete[] new_buffer;
       return {false, slot};
     }
 

--- a/src/storage/storage_util.cpp
+++ b/src/storage/storage_util.cpp
@@ -78,20 +78,17 @@ void StorageUtil::CopyProjectionIntoProjection(const RowType1 &from, const Proje
         // get the size of the attribute
         uint8_t attr_size = layout.AttrSize(from.ColumnIds()[it.second]);
 
-        // get the address where we copy into
-        uint16_t offset = to_map.at(it.first);
-
         byte *addr = to->AccessForceNotNull(offset);
         // Copy things over
         std::memcpy(addr, value, attr_size);
       }
     }
-    // Fill with default values
-    // TODO(yangjuns): fill will default values instead of setting it to be null
-    for (auto &it : to_map) {
-      if (from_map.count(it.first) == 0) {
-        to->SetNull(it.second);
-      }
+  }
+  // Fill with default values
+  // TODO(yangjuns): fill will default values instead of setting it to be null
+  for (auto &it : to_map) {
+    if (from_map.count(it.first) == 0) {
+      to->SetNull(it.second);
     }
   }
 }


### PR DESCRIPTION
1. It fixes memory leak when lookup a slot that doesn't exist 
2. It uses DataTable-level operations instead of recursions for consistency and readability. 