### PR TITLE
Concurrent map

### DIFF
--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -204,7 +204,6 @@ class PACKED ProjectedColumns {
                                                          common::RawBitmap::SizeInBytes(max_tuples_));
   }
 
-
  private:
   friend class ProjectedColumnsInitializer;
   uint32_t size_;

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -5,6 +5,8 @@
 #include <utility>
 #include <vector>
 #include "catalog/schema.h"
+#include "common/container/concurrent_map.h"
+#include "common/macros.h"
 #include "loggers/storage_logger.h"
 #include "storage/data_table.h"
 #include "storage/projected_columns.h"
@@ -56,8 +58,9 @@ class SqlTable {
      * @return self-reference after the iterator is advanced
      */
     SlotIterator &operator++() {
-      dt_version_++;
-      current_it_ = (*dt_version_).second.data_table->begin();
+      TERRIER_ASSERT(!is_end_, "Cannot increment an end iterator");
+      current_it_++;
+      AdvanceOnEndOfDatatable_();
       return *this;
     }
 
@@ -72,11 +75,15 @@ class SqlTable {
     }
 
     /**
-     * Equality check.
+     * Equality check.  Either both iterators are "end" or they must match
+     * on both their observed version and the underlying tuple.
      * @param other other iterator to compare to
      * @return if the two iterators point to the same slotcolumn_ids
      */
-    bool operator==(const SlotIterator &other) const { return current_it_ == other.current_it_; }
+    bool operator==(const SlotIterator &other) const {
+      // First "is_end" check is that both are end, the second protects the iterator check through short-circuit
+      return (is_end_ && other.is_end_) || (is_end_ == other.is_end_ && txn_version_ == other.txn_version_ && current_it_ == other.current_it_);
+    }
 
     /**
      * Inequality check.
@@ -85,19 +92,48 @@ class SqlTable {
      */
     bool operator!=(const SlotIterator &other) const { return !this->operator==(other); }
 
-    DataTable::SlotIterator GetDataTableSlotIterator() { return current_it_; }
+    DataTable::SlotIterator *GetDataTableSlotIterator() { return &current_it_; }
 
    private:
     friend class SqlTable;
-    /**
-     * @warning MUST BE CALLED ONLY WHEN CALLER HOLDS LOCK TO THE LIST OF RAW BLOCKS IN THE DATA TABLE
-     */
-    SlotIterator(std::map<layout_version_t, DataTableVersion>::const_iterator dt_version,
-                 DataTable::SlotIterator dt_slot_it)
-        : dt_version_(dt_version), current_it_(dt_slot_it) {}
 
-    std::map<layout_version_t, DataTableVersion>::const_iterator dt_version_;
+    SlotIterator(const common::ConcurrentMap<layout_version_t, DataTableVersion> *tables, const layout_version_t txn_version, bool is_end)
+        : tables_(tables), current_it_(tables_->Find(txn_version)->second.data_table->begin()) {
+      txn_version_ = txn_version;
+      curr_version_ = txn_version;
+      is_end_ = is_end;
+    }
+
+    /**
+     * Checks if DataTable::SlotIterator is at the end of the table and advances
+     * the iterator to the next table or sets is_end flag as appropriate.  This
+     * refactor is necessary to keep iterator in correct state when used in two
+     * distinct ways:  increment called directly on this object or implicitly
+     * through advancement of the DataTable iterator in SqlTable::Scan.
+     */
+    void AdvanceOnEndOfDatatable_() {
+      if (current_it_ == tables_->Find(curr_version_)->second.data_table->end()) {
+        // layout_version_t is uint32_t so we need to protect against underflow.
+        if (!curr_version_ == 0) {
+          is_end_ = true;
+          return;
+        }
+        curr_version_--;
+        TERRIER_ASSERT(curr_version_ < txn_version_, "Current version must be older than transaction");
+        auto next_table = tables_->Find(curr_version_);
+        if (next_table == tables_->CEnd()) { // next_table does not exist (at end)
+          is_end_ = true;
+        } else { // next_table is valid
+          current_it_ = next_table->second.data_table->begin();
+        }
+      }
+    }
+
+    const common::ConcurrentMap<layout_version_t, DataTableVersion> *tables_;
+    layout_version_t txn_version_;
+    layout_version_t curr_version_;
     DataTable::SlotIterator current_it_;
+    bool is_end_;
   };
 
  public:
@@ -167,7 +203,7 @@ class SqlTable {
     // TODO(Matt): check constraints? Discuss if that happens in execution layer or not
     // TODO(Matt): update indexes
     // always insert into the new DataTable
-    return tables_.at(version_num).data_table->Insert(txn, redo);
+    return tables_.Find(version_num)->second.data_table->Insert(txn, redo);
   }
 
   /**
@@ -182,7 +218,7 @@ class SqlTable {
     // TODO(Matt): update indexes
     layout_version_t old_version = slot.GetBlock()->layout_version_;
     // always delete the tuple in the old block
-    return tables_.at(old_version).data_table->Delete(txn, slot);
+    return tables_.Find(old_version)->second.data_table->Delete(txn, slot);
   }
 
   /**
@@ -205,9 +241,9 @@ class SqlTable {
   /**
    * @return the first tuple slot contained in the data table
    */
-  SlotIterator begin() const {
+  SlotIterator begin(layout_version_t txn_version) const {
     // common::SpinLatch::ScopedSpinLatch guard(&tables_latch_);
-    return SlotIterator(tables_.begin(), tables_.begin()->second.data_table->begin());
+    return SlotIterator(&tables_, txn_version, false);
   }
 
   /**
@@ -220,7 +256,7 @@ class SqlTable {
    */
   SlotIterator end() const {
     // common::SpinLatch::ScopedSpinLatch guard(&tables_latch_);
-    return SlotIterator(--tables_.end(), (--tables_.end())->second.data_table->end());
+    return SlotIterator(&tables_, tables_.CBegin()->first, true);
   }
 
   /**
@@ -245,7 +281,7 @@ class SqlTable {
     auto col_ids = ColIdsForOids(col_oids, version_num);
     TERRIER_ASSERT(col_ids.size() == col_oids.size(),
                    "Projection should be the same number of columns as requested col_oids.");
-    ProjectedColumnsInitializer initializer(tables_.at(version_num).layout, col_ids, max_tuples);
+    ProjectedColumnsInitializer initializer(tables_.Find(version_num)->second.layout, col_ids, max_tuples);
     auto projection_map = ProjectionMapForInitializer<ProjectedColumnsInitializer>(initializer, version_num);
     TERRIER_ASSERT(projection_map.size() == col_oids.size(),
                    "ProjectionMap be the same number of columns as requested col_oids.");
@@ -269,7 +305,7 @@ class SqlTable {
     auto col_ids = ColIdsForOids(col_oids, version_num);
     TERRIER_ASSERT(col_ids.size() == col_oids.size(),
                    "Projection should be the same number of columns as requested col_oids.");
-    ProjectedRowInitializer initializer(tables_.at(version_num).layout, col_ids);
+    ProjectedRowInitializer initializer(tables_.Find(version_num)->second.layout, col_ids);
     auto projection_map = ProjectionMapForInitializer<ProjectedRowInitializer>(initializer, version_num);
     TERRIER_ASSERT(projection_map.size() == col_oids.size(),
                    "ProjectionMap be the same number of columns as requested col_oids.");
@@ -281,7 +317,7 @@ class SqlTable {
   const catalog::table_oid_t oid_;
 
   // Eventually we'll support adding more tables when schema changes. For now we'll always access the one DataTable.
-  std::map<layout_version_t, DataTableVersion> tables_;
+  common::ConcurrentMap<layout_version_t, DataTableVersion> tables_;
 
   /**
    * Given a set of col_oids, return a vector of corresponding col_ids to use for ProjectionInitialization

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -82,7 +82,8 @@ class SqlTable {
      */
     bool operator==(const SlotIterator &other) const {
       // First "is_end" check is that both are end, the second protects the iterator check through short-circuit
-      return (is_end_ && other.is_end_) || (is_end_ == other.is_end_ && txn_version_ == other.txn_version_ && current_it_ == other.current_it_);
+      return (is_end_ && other.is_end_) ||
+             (is_end_ == other.is_end_ && txn_version_ == other.txn_version_ && current_it_ == other.current_it_);
     }
 
     /**
@@ -97,7 +98,8 @@ class SqlTable {
    private:
     friend class SqlTable;
 
-    SlotIterator(const common::ConcurrentMap<layout_version_t, DataTableVersion> *tables, const layout_version_t txn_version, bool is_end)
+    SlotIterator(const common::ConcurrentMap<layout_version_t, DataTableVersion> *tables,
+                 const layout_version_t txn_version, bool is_end)
         : tables_(tables), current_it_(tables_->Find(txn_version)->second.data_table->begin()) {
       txn_version_ = txn_version;
       curr_version_ = txn_version;
@@ -121,9 +123,9 @@ class SqlTable {
         curr_version_--;
         TERRIER_ASSERT(curr_version_ < txn_version_, "Current version must be older than transaction");
         auto next_table = tables_->Find(curr_version_);
-        if (next_table == tables_->CEnd()) { // next_table does not exist (at end)
+        if (next_table == tables_->CEnd()) {  // next_table does not exist (at end)
           is_end_ = true;
-        } else { // next_table is valid
+        } else {  // next_table is valid
           current_it_ = next_table->second.data_table->begin();
         }
       }
@@ -349,6 +351,6 @@ class SqlTable {
    */
   template <class RowType>
   void ModifyProjectionHeaderForVersion(RowType *out_buffer, const DataTableVersion &curr_dt_version,
-                                        const DataTableVersion &old_dt_version, col_id_t * original_col_id_store) const;
+                                        const DataTableVersion &old_dt_version, col_id_t *original_col_id_store) const;
 };
 }  // namespace terrier::storage

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -204,7 +204,7 @@ bool DataTable::SelectIntoBuffer(transaction::TransactionContext *const txn, con
     // can potentially happen, and chase the version chain before returning anyway,
     for (uint16_t i = 0; i < out_buffer->NumColumns(); i++) {
       if (out_buffer->ColumnIds()[i] == VERSION_POINTER_COLUMN_ID) {
-        out_buffer->SetNull(i); // If we don't have this column, make sure its marked NULL
+        out_buffer->SetNull(i);  // If we don't have this column, make sure its marked NULL
         continue;
       }
       StorageUtil::CopyAttrIntoProjection(accessor_, slot, out_buffer, i);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -204,6 +204,7 @@ bool DataTable::SelectIntoBuffer(transaction::TransactionContext *const txn, con
     // can potentially happen, and chase the version chain before returning anyway,
     for (uint16_t i = 0; i < out_buffer->NumColumns(); i++) {
       if (out_buffer->ColumnIds()[i] == VERSION_POINTER_COLUMN_ID) {
+        out_buffer->SetNull(i); // If we don't have this column, make sure its marked NULL
         continue;
       }
       StorageUtil::CopyAttrIntoProjection(accessor_, slot, out_buffer, i);

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -248,7 +248,8 @@ std::pair<bool, storage::TupleSlot> SqlTable::Update(transaction::TransactionCon
     bool succ = tables_.Find(old_version)->second.data_table->Delete(txn, slot);
 
     // 4. Update the new row before insert
-    StorageUtil::CopyProjectionIntoProjection(redo, map, tables_.Find(version_num)->second.layout, new_pr, new_pair.second);
+    StorageUtil::CopyProjectionIntoProjection(redo, map, tables_.Find(version_num)->second.layout, new_pr,
+                                              new_pair.second);
 
     // 5. Insert the row into new table
     storage::TupleSlot new_slot;

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -50,7 +50,7 @@ class SqlTableTestRW {
     col_oids_.clear();
     for (const auto &c : cols_) {
       col_oids_.emplace_back(c.GetOid());
-      LOG_INFO("{}", !c.GetOid());
+      // LOG_INFO("{}", !c.GetOid());
     }
 
     delete pri_;
@@ -446,7 +446,7 @@ TEST_F(SqlTableTests, UpdateTest) {
   EXPECT_EQ(new_val, 11001);
 
   // update (400, 10003, 42) -> (400, 11003, 420)
-  LOG_INFO("----------------------------")
+  // LOG_INFO("----------------------------")
   update_oids.clear();
   update_oids.emplace_back(catalog::col_oid_t(1));
   update_oids.emplace_back(catalog::col_oid_t(2));
@@ -464,7 +464,7 @@ TEST_F(SqlTableTests, UpdateTest) {
   EXPECT_EQ(new_val, 420);
 
   // update (100, 10000, null) -> (100, 11000, 420)
-  LOG_INFO("----------------------------")
+  // LOG_INFO("----------------------------")
   update_oids.clear();
   update_oids.emplace_back(catalog::col_oid_t(1));
   update_oids.emplace_back(catalog::col_oid_t(2));
@@ -486,6 +486,25 @@ TEST_F(SqlTableTests, UpdateTest) {
 
 // NOLINTNEXTLINE
 TEST_F(SqlTableTests, ScanTest) {
+  std::map<uint32_t, uint32_t> datname_map;
+  std::map<uint32_t, uint32_t> new_col_map;
+  std::map<uint32_t, bool> seen_map;
+
+  datname_map[100] = 10000;
+  datname_map[200] = 10001;
+  datname_map[300] = 10002;
+  datname_map[400] = 10003;
+
+  // new_col_map[100] = NULL (created before column added)
+  // new_col_map[200] = NULL (created before column added)
+  // new_col_map[300] = NULL (inserted without value)
+  new_col_map[400] = 42;
+
+  seen_map[100] = false;
+  seen_map[200] = false;
+  seen_map[300] = false;
+  seen_map[400] = false;
+
   SqlTableTestRW table(catalog::table_oid_t(2));
   auto txn = txn_manager_.BeginTransaction();
   table.DefineColumn("id", type::TypeId::INTEGER, false, catalog::col_oid_t(0));
@@ -495,13 +514,13 @@ TEST_F(SqlTableTests, ScanTest) {
   // insert (100, 10000)
   table.StartInsertRow();
   table.SetIntColInRow(catalog::col_oid_t(0), 100);
-  table.SetIntColInRow(catalog::col_oid_t(1), 10000);
+  table.SetIntColInRow(catalog::col_oid_t(1), datname_map[100]);
   table.EndInsertRow(txn);
 
   // insert (200, 10001)
   table.StartInsertRow();
   table.SetIntColInRow(catalog::col_oid_t(0), 200);
-  table.SetIntColInRow(catalog::col_oid_t(1), 10001);
+  table.SetIntColInRow(catalog::col_oid_t(1), datname_map[200]);
   table.EndInsertRow(txn);
 
   // manually set the version of the transaction to be 1
@@ -511,14 +530,14 @@ TEST_F(SqlTableTests, ScanTest) {
   // insert (300, 10002, null)
   table.StartInsertRow();
   table.SetIntColInRow(catalog::col_oid_t(0), 300);
-  table.SetIntColInRow(catalog::col_oid_t(1), 10002);
+  table.SetIntColInRow(catalog::col_oid_t(1), datname_map[300]);
   table.EndInsertRow(txn);
 
   // insert (400, 10003, 42)
   table.StartInsertRow();
   table.SetIntColInRow(catalog::col_oid_t(0), 400);
-  table.SetIntColInRow(catalog::col_oid_t(1), 10003);
-  table.SetIntColInRow(catalog::col_oid_t(2), 42);
+  table.SetIntColInRow(catalog::col_oid_t(1), datname_map[400]);
+  table.SetIntColInRow(catalog::col_oid_t(2), new_col_map[400]);
   table.EndInsertRow(txn);
 
   // begin scan
@@ -532,51 +551,95 @@ TEST_F(SqlTableTests, ScanTest) {
   storage::ProjectedColumns *pc = pc_pair.first.Initialize(buffer);
 
   // scan
-  auto start_pos = table.table_->begin();
+  auto start_pos = table.table_->begin(table.version_);
   table.table_->Scan(txn, &start_pos, pc, pc_pair.second, table.version_);
+  EXPECT_TRUE(start_pos != table.table_->end());
 
   // check the number of tuples we found
   EXPECT_EQ(pc->NumTuples(), 2);
 
-  // check the if we get (100, 10000, null)
   auto row1 = pc->InterpretAsRow(*table.GetLayout(), 0);
   byte *value = row1.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(0)));
   EXPECT_NE(value, nullptr);
   uint32_t id = *reinterpret_cast<uint32_t *>(value);
-  EXPECT_EQ(id, 100);
+  EXPECT_FALSE(seen_map[id]);
+  seen_map[id] = true;
   value = row1.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(1)));
   EXPECT_NE(value, nullptr);
   uint32_t datname = *reinterpret_cast<uint32_t *>(value);
-  EXPECT_EQ(datname, 10000);
+  EXPECT_EQ(datname, datname_map[id]);
+  value = row1.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(2)));
+  if (id != 400) {
+    EXPECT_EQ(value, nullptr);
+  } else {
+    uint32_t new_col = *reinterpret_cast<uint32_t *>(value);
+    EXPECT_EQ(new_col, new_col_map[id]);
+  }
 
   // check the if we get (200, 10001, null)
   auto row2 = pc->InterpretAsRow(*table.GetLayout(), 1);
   value = row2.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(0)));
   EXPECT_NE(value, nullptr);
   id = *reinterpret_cast<uint32_t *>(value);
-  EXPECT_EQ(id, 200);
+  EXPECT_FALSE(seen_map[id]);
+  seen_map[id] = true;
   value = row2.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(1)));
   EXPECT_NE(value, nullptr);
   datname = *reinterpret_cast<uint32_t *>(value);
-  EXPECT_EQ(datname, 10001);
+  EXPECT_EQ(datname, datname_map[id]);
+  value = row2.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(2)));
+  if (id != 400) {
+    EXPECT_EQ(value, nullptr);
+  } else {
+    uint32_t new_col = *reinterpret_cast<uint32_t *>(value);
+    EXPECT_EQ(new_col, new_col_map[id]);
+  }
 
   pc = pc_pair.first.Initialize(buffer);
   // Need to scan again to get the rest of the data
   table.table_->Scan(txn, &start_pos, pc, pc_pair.second, table.version_);
-  // check the if we get (400, 10003, 42)
+  EXPECT_EQ(pc->NumTuples(), 2);
+  EXPECT_TRUE(start_pos == table.table_->end());
+
+  auto row3 = pc->InterpretAsRow(*table.GetLayout(), 0);
+  value = row3.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(0)));
+  EXPECT_NE(value, nullptr);
+  id = *reinterpret_cast<uint32_t *>(value);
+  EXPECT_FALSE(seen_map[id]);
+  seen_map[id] = true;
+  value = row3.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(1)));
+  EXPECT_NE(value, nullptr);
+  datname = *reinterpret_cast<uint32_t *>(value);
+  EXPECT_EQ(datname, datname_map[id]);
+  value = row3.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(2)));
+  if (id != 400) {
+    EXPECT_EQ(value, nullptr);
+  } else {
+    uint32_t new_col = *reinterpret_cast<uint32_t *>(value);
+    EXPECT_EQ(new_col, new_col_map[id]);
+  }
+
+  // check the if we get (200, 10001, null)
   auto row4 = pc->InterpretAsRow(*table.GetLayout(), 1);
   value = row4.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(0)));
   EXPECT_NE(value, nullptr);
   id = *reinterpret_cast<uint32_t *>(value);
-  EXPECT_EQ(id, 400);
+  EXPECT_FALSE(seen_map[id]);
+  seen_map[id] = true;
   value = row4.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(1)));
   EXPECT_NE(value, nullptr);
   datname = *reinterpret_cast<uint32_t *>(value);
-  EXPECT_EQ(datname, 10003);
+  EXPECT_EQ(datname, datname_map[id]);
   value = row4.AccessWithNullCheck(pc_pair.second.at(catalog::col_oid_t(2)));
-  EXPECT_NE(value, nullptr);
-  uint32_t new_col = *reinterpret_cast<uint32_t *>(value);
-  EXPECT_EQ(new_col, 42);
+  if (id != 400) {
+    EXPECT_EQ(value, nullptr);
+  } else {
+    uint32_t new_col = *reinterpret_cast<uint32_t *>(value);
+    EXPECT_EQ(new_col, new_col_map[id]);
+  }
+
+  for (auto iter : seen_map)
+    EXPECT_TRUE(iter.second);
 
   delete[] buffer;
   txn_manager_.Commit(txn, TestCallbacks::EmptyCallback, nullptr);

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -1,6 +1,7 @@
 #include "storage/sql_table.h"
 #include <algorithm>
 #include <cstring>
+#include <map>
 #include <random>
 #include <string>
 #include <utility>
@@ -638,8 +639,7 @@ TEST_F(SqlTableTests, ScanTest) {
     EXPECT_EQ(new_col, new_col_map[id]);
   }
 
-  for (auto iter : seen_map)
-    EXPECT_TRUE(iter.second);
+  for (auto iter : seen_map) EXPECT_TRUE(iter.second);
 
   delete[] buffer;
   txn_manager_.Commit(txn, TestCallbacks::EmptyCallback, nullptr);


### PR DESCRIPTION
Updates the internal representation for versioned DataTable objects to use the wrapper for TBB's concurrent unordered hash map.  The switch highlighted invalid assumptions in the SQL table test (scan does not guarantee any ordering on results) as well as a logic error in populating old versions into new versions (need to set null on missing columns).