### PR TITLE
Fix bad iterator situation

### DIFF
--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -243,7 +243,9 @@ class SqlTable {
    */
   SlotIterator begin(layout_version_t txn_version) const {
     // common::SpinLatch::ScopedSpinLatch guard(&tables_latch_);
-    return SlotIterator(&tables_, txn_version, false);
+    auto ret = SlotIterator(&tables_, txn_version, false);
+    ret.AdvanceOnEndOfDatatable_();
+    return ret;
   }
 
   /**


### PR DESCRIPTION
Fixes the issue identified in #30.  Specifically,  the first table for the iterator may not contain any tuples.  In this situation, we ended up derefencing a `nullptr` in `SqlTable::Scan`.  The solution is to call `AdvanceOnEndOfTable_` on it before returning it to the caller.