### PR TITLE
Asan hotfix

### DIFF
--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -107,7 +107,7 @@ class Schema {
     /**
      * @return default value for this column
      */
-    byte *GetDefault() const { return (default_is_null_) ? nullptr : &default_; }
+    byte *GetDefault() const { return (default_is_null_) ? nullptr : reinterpret_cast<byte *>&default_; }
 
     /**
      * Set the default value of the column

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -76,6 +76,16 @@ class Schema {
       TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
     }
 
+    Column(const Column &col)
+        : name_(std::move(col.name_)),
+          type_(col.type_),
+          attr_size_(type::TypeUtil::GetTypeSize(type_)),
+          nullable_(col.nullable_),
+          oid_(col.oid_),
+          default_(nullptr) {
+      SetDefault(col.default_);
+    }
+
     /**
      * Free the memory allocated to default_ in the destructor
      */
@@ -130,7 +140,7 @@ class Schema {
         // Free the memory allocated to the default value
         delete default_;
         default_ = nullptr;
-      } else {
+      } else if (default_value != nullptr) {
         if (default_ == nullptr) {
           default_ = new byte[attr_size_];
         }

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -107,7 +107,7 @@ class Schema {
     /**
      * @return default value for this column
      */
-    byte *GetDefault() const { return (default_is_null_) ? nullptr : reinterpret_cast<byte *>&default_; }
+    const byte *GetDefault() const { return (default_is_null_) ? nullptr : &default_; }
 
     /**
      * Set the default value of the column

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -107,7 +107,7 @@ class Schema {
     /**
      * @return default value for this column
      */
-    byte *GetDefault() const { return default_; }
+    byte *GetDefault() const { return (default_is_null_) ? nullptr : &default_; }
 
     /**
      * Set the default value of the column

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -42,7 +42,7 @@ class Schema {
           type_(type),
           attr_size_(type::TypeUtil::GetTypeSize(type_)),
           nullable_(nullable),
-          oid_(oid){
+          oid_(oid) {
       TERRIER_ASSERT(attr_size_ == 1 || attr_size_ == 2 || attr_size_ == 4 || attr_size_ == 8,
                      "This constructor is meant for non-VARLEN columns.");
       TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
@@ -68,7 +68,7 @@ class Schema {
           attr_size_(type::TypeUtil::GetTypeSize(type_)),
           max_varlen_size_(max_varlen_size),
           nullable_(nullable),
-          oid_(oid){
+          oid_(oid) {
       // TODO(Sai): How to handle default values for VARLEN?
       TERRIER_ASSERT(attr_size_ == VARLEN_COLUMN, "This constructor is meant for VARLEN columns.");
       TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -79,7 +79,12 @@ class Schema {
     /**
      * Free the memory allocated to default_ in the destructor
      */
-    ~Column() = default;
+    ~Column() {
+      if (default_ != nullptr) {
+        delete[] default_;
+        default_ = nullptr;
+      }
+    }
 
     /**
      * @return column name

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -42,8 +42,7 @@ class Schema {
           type_(type),
           attr_size_(type::TypeUtil::GetTypeSize(type_)),
           nullable_(nullable),
-          oid_(oid),
-          default_(nullptr) {
+          oid_(oid){
       TERRIER_ASSERT(attr_size_ == 1 || attr_size_ == 2 || attr_size_ == 4 || attr_size_ == 8,
                      "This constructor is meant for non-VARLEN columns.");
       TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
@@ -69,11 +68,11 @@ class Schema {
           attr_size_(type::TypeUtil::GetTypeSize(type_)),
           max_varlen_size_(max_varlen_size),
           nullable_(nullable),
-          oid_(oid),
-          default_(nullptr) {
+          oid_(oid){
       // TODO(Sai): How to handle default values for VARLEN?
       TERRIER_ASSERT(attr_size_ == VARLEN_COLUMN, "This constructor is meant for VARLEN columns.");
       TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
+      SetDefault(default_value);
     }
 
     /**

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -50,9 +50,7 @@ class Schema {
 
       // ASSUMPTION: The default_value passed in is of size attr_size_
       // Copy the passed in default value (if exists)
-      if (default_value != nullptr) {
-        SetDefault(default_value);
-      }
+      SetDefault(default_value);
     }
 
     /**
@@ -62,38 +60,20 @@ class Schema {
      * @param max_varlen_size the maximum length of the varlen entry
      * @param nullable true if the column is nullable, false otherwise
      * @param oid internal unique identifier for this column
+     * @param default_value default value for this column. Null by default
      */
     Column(std::string name, const type::TypeId type, const uint16_t max_varlen_size, const bool nullable,
-           const col_oid_t oid)
+           const col_oid_t oid, byte *default_value = nullptr)
         : name_(std::move(name)),
           type_(type),
           attr_size_(type::TypeUtil::GetTypeSize(type_)),
           max_varlen_size_(max_varlen_size),
           nullable_(nullable),
-          oid_(oid) {
+          oid_(oid),
+          default_(nullptr) {
       // TODO(Sai): How to handle default values for VARLEN?
       TERRIER_ASSERT(attr_size_ == VARLEN_COLUMN, "This constructor is meant for VARLEN columns.");
       TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
-    }
-
-    Column(const Column &col)
-        : name_(std::move(col.name_)),
-          type_(col.type_),
-          attr_size_(type::TypeUtil::GetTypeSize(type_)),
-          nullable_(col.nullable_),
-          oid_(col.oid_),
-          default_(nullptr) {
-      SetDefault(col.default_);
-    }
-
-    /**
-     * Free the memory allocated to default_ in the destructor
-     */
-    ~Column() {
-      if (default_ != nullptr) {
-        delete[] default_;
-        default_ = nullptr;
-      }
     }
 
     /**
@@ -135,18 +115,9 @@ class Schema {
      * @param default_value default_value as a bytes array. Could be nullptr
      */
     void SetDefault(byte *default_value) {
+      default_is_null_ = (default_value == nullptr);
       // If explicitly setting the default value to null
-      if (default_value == nullptr && default_ != nullptr) {
-        // Free the memory allocated to the default value
-        delete default_;
-        default_ = nullptr;
-      } else if (default_value != nullptr) {
-        if (default_ == nullptr) {
-          default_ = new byte[attr_size_];
-        }
-        // Copy the new default value
-        std::memcpy(default_, default_value, attr_size_);
-      }
+      if (!default_is_null_) std::memcpy(default_, default_value, attr_size_);
     }
 
     /**
@@ -190,7 +161,8 @@ class Schema {
     col_oid_t oid_;
     // TODO(Sai): Consider having a DefaultValueObject containing isNull, 16-byte variable and attribute size
     // This avoids handling memory explicitly for default values
-    byte *default_;
+    byte default_[16];
+    bool default_is_null_
   };
 
   /**

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -107,7 +107,7 @@ class Schema {
     /**
      * @return default value for this column
      */
-    const byte *GetDefault() const { return (default_is_null_) ? nullptr : &default_; }
+    const byte *GetDefault() const { return (default_is_null_) ? nullptr : reinterpret_cast<const byte *>(&default_); }
 
     /**
      * Set the default value of the column

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -161,7 +161,7 @@ class Schema {
     // TODO(Sai): Consider having a DefaultValueObject containing isNull, 16-byte variable and attribute size
     // This avoids handling memory explicitly for default values
     byte default_[16];
-    bool default_is_null_
+    bool default_is_null_;
   };
 
   /**

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -182,7 +182,7 @@ using InverseColumnMap = std::unordered_map<col_id_t, catalog::col_oid_t>;
  * Used by SqlTable to map between col_oids in Schema and their {default_value, attribute_size}
  */
 // using DefaultValueMap = std::unordered_map<catalog::col_oid_t, std::pair<byte *, uint8_t>>;
-using DefaultValueMap = common::ConcurrentMap<catalog::col_oid_t, std::pair<byte *, uint8_t>>;
+using DefaultValueMap = common::ConcurrentMap<catalog::col_oid_t, std::pair<const byte *, uint8_t>>;
 
 /**
  * Denote whether a record modifies the logical delete column, used when DataTable inspects deltas

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -15,6 +15,12 @@ SqlTable::SqlTable(BlockStore *const store, const catalog::Schema &schema, const
 }
 
 SqlTable::~SqlTable() {
+  while (default_value_map_.CBegin() != default_value_map_.CEnd()) {
+    auto pair = *(default_value_map_.CBegin());
+    delete[] pair.second.first;
+    default_value_map_.UnsafeErase(pair.first);
+  }
+
   while (tables_.CBegin() != tables_.CEnd()) {
     auto pair = *(tables_.CBegin());
     delete (pair.second.data_table);  // Delete the data_table object on the heap
@@ -82,7 +88,12 @@ void SqlTable::UpdateSchema(const catalog::Schema &schema) {
     // Only populate the default values of the columns which are new and have a default value
     if (default_value_map_.Find(col_oid) == default_value_map_.End()) {
       uint8_t attr_size = column.GetAttrSize();
-      default_value_map_.Insert(column.GetOid(), {default_value, attr_size});
+      byte *temp = nullptr;
+      if (default_value != nullptr) {
+        temp = new byte[attr_size];
+        std::memcpy(temp, default_value, attr_size);
+      }
+      default_value_map_.Insert(column.GetOid(), {temp, attr_size});
     }
   }
 

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -78,7 +78,7 @@ void SqlTable::UpdateSchema(const catalog::Schema &schema) {
   // Populate the default value map
   for (const auto &column : schema.GetColumns()) {
     auto col_oid = column.GetOid();
-    byte *default_value = column.GetDefault();
+    auto *default_value = column.GetDefault();
     // Only populate the default values of the columns which are new and have a default value
     if (default_value_map_.Find(col_oid) == default_value_map_.End()) {
       uint8_t attr_size = column.GetAttrSize();

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -845,7 +845,8 @@ TEST_F(SqlTableTests, BasicDefaultValuesTest) {
   // Explicitly set the layout version number
   table.version_ = storage::layout_version_t(1);
   int col2_default = 42;
-  table.AddColumn(txn, "col2", type::TypeId::INTEGER, true, catalog::col_oid_t(2), reinterpret_cast<byte *>(&col2_default));
+  table.AddColumn(txn, "col2", type::TypeId::INTEGER, true, catalog::col_oid_t(2),
+                  reinterpret_cast<byte *>(&col2_default));
 
   // Insert (2, NULL, 890)
   table.StartInsertRow();
@@ -864,7 +865,8 @@ TEST_F(SqlTableTests, BasicDefaultValuesTest) {
   // Add another column with a default value and insert a row
   table.version_ = storage::layout_version_t(2);
   int col3_default = 1729;
-  table.AddColumn(txn, "col3", type::TypeId::INTEGER, true, catalog::col_oid_t(3), reinterpret_cast<byte *>(&col3_default));
+  table.AddColumn(txn, "col3", type::TypeId::INTEGER, true, catalog::col_oid_t(3),
+                  reinterpret_cast<byte *>(&col3_default));
 
   // Insert (3, 300, NULL, NULL)
   table.StartInsertRow();

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -316,17 +316,6 @@ class SqlTableTestRW {
     }
   }
 
-  /**
-   * Convert an integer to byte array
-   * @param n an integer
-   * @return byte array
-   */
-  byte *IntToByteArray(int n) {
-    auto byteArray = new byte[sizeof(n)];
-    memcpy(byteArray, reinterpret_cast<char *>(&n), sizeof(n));
-    return byteArray;
-  }
-
  public:
   // This is a public field that transactions can set and read.
   // The purpose is to record the version for each transaction. In reality this information should be retrieved from
@@ -399,7 +388,7 @@ TEST_F(SqlTableTests, SelectTest) {
   int default_val = 42;
   // Add a new column with a default value
   table.AddColumn(txn, "new_col", type::TypeId::INTEGER, true, catalog::col_oid_t(2),
-                  table.IntToByteArray(default_val));
+                  reinterpret_cast<byte *>(&default_val));
 
   id = table.GetIntColInRow(txn, catalog::col_oid_t(0), row1_slot);
   EXPECT_EQ(100, id);
@@ -655,7 +644,7 @@ TEST_F(SqlTableTests, ScanTest) {
   // manually set the version of the transaction to be 1
   table.version_ = storage::layout_version_t(1);
   table.AddColumn(txn, "new_col", type::TypeId::INTEGER, true, catalog::col_oid_t(2),
-                  table.IntToByteArray(new_col_default_value));
+                  reinterpret_cast<byte *>(&new_col_default_value));
 
   // insert (300, 10002, 1729) - Default value populated by the execution engine
   table.StartInsertRow();
@@ -856,7 +845,7 @@ TEST_F(SqlTableTests, BasicDefaultValuesTest) {
   // Explicitly set the layout version number
   table.version_ = storage::layout_version_t(1);
   int col2_default = 42;
-  table.AddColumn(txn, "col2", type::TypeId::INTEGER, true, catalog::col_oid_t(2), table.IntToByteArray(col2_default));
+  table.AddColumn(txn, "col2", type::TypeId::INTEGER, true, catalog::col_oid_t(2), reinterpret_cast<byte *>(&col2_default));
 
   // Insert (2, NULL, 890)
   table.StartInsertRow();
@@ -875,7 +864,7 @@ TEST_F(SqlTableTests, BasicDefaultValuesTest) {
   // Add another column with a default value and insert a row
   table.version_ = storage::layout_version_t(2);
   int col3_default = 1729;
-  table.AddColumn(txn, "col3", type::TypeId::INTEGER, true, catalog::col_oid_t(3), table.IntToByteArray(col3_default));
+  table.AddColumn(txn, "col3", type::TypeId::INTEGER, true, catalog::col_oid_t(3), reinterpret_cast<byte *>(&col3_default));
 
   // Insert (3, 300, NULL, NULL)
   table.StartInsertRow();
@@ -950,9 +939,8 @@ TEST_F(SqlTableTests, ModifyDefaultValuesTest) {
 
   // Now set the default value of the column to something
   int col2_default = 42;
-  byte *col2_default_bytes = table.IntToByteArray(col2_default);
+  byte *col2_default_bytes = reinterpret_cast<byte *>(&col2_default);
   table.SetColumnDefault(catalog::col_oid_t(2), col2_default_bytes);
-  delete[] col2_default_bytes;
 
   // Add a new column - to trigger the UpdateSchema
   table.version_ = storage::layout_version_t(2);

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -941,7 +941,7 @@ TEST_F(SqlTableTests, ModifyDefaultValuesTest) {
 
   // Now set the default value of the column to something
   int col2_default = 42;
-  byte *col2_default_bytes = reinterpret_cast<byte *>(&col2_default);
+  auto *col2_default_bytes = reinterpret_cast<byte *>(&col2_default);
   table.SetColumnDefault(catalog::col_oid_t(2), col2_default_bytes);
 
   // Add a new column - to trigger the UpdateSchema


### PR DESCRIPTION
Hotfix to solve memory leak in default values.  Makes the following major changes:
1. Deallocates local allocations in SqlTable tests.
2. Refactors `Schema::Column` to have the default values in line with a separate boolean for tracking is null (fixes aliasing and lifetime issues when creating a schema)
3. Refactors `default_value_map_` logic to handle allocation and deallocation so that lifetime of the default values is directly controlled by SqlTable.

This code passes build checks locally (to include ASAN).